### PR TITLE
bump dino_park_gate 0.9->0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 proc-macro = true
 
 [dependencies]
-dino_park_gate = { git = "https://github.com/mozilla-iam/dino-park-gate", branch = "0.9", version = "0.9" }
+dino_park_gate = { git = "https://github.com/mozilla-iam/dino-park-gate", branch = "0.9.1", version = "0.9.1" }
 dino_park_trust = { git = "https://github.com/mozilla-iam/dino-park-trust", branch = "0.1", version = "0.1" }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"


### PR DESCRIPTION
To deploy the issue identified in https://github.com/mozilla-iam/dino-park-gate/issues/7, we need to bump the version number here as well. The associated branch/version are prepared in the repository.