### PR TITLE
Update dino-park-trust dependency for consistency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ proc-macro = true
 
 [dependencies]
 dino_park_gate = { git = "https://github.com/mozilla-iam/dino-park-gate", branch = "0.9.1", version = "0.9.1" }
-dino_park_trust = { git = "https://github.com/mozilla-iam/dino-park-trust", branch = "0.1", version = "0.1" }
+dino_park_trust = { git = "https://github.com/mozilla-iam/dino-park-trust", branch = "0.3", version = "0.3" }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 


### PR DESCRIPTION
This PR brings the dino-park-trust package into alignment so that we're not using a mix of 0.1 and 0.3 branches across our code.

Cargo.lock will need to be regenerated.